### PR TITLE
Improve guidance around contributions

### DIFF
--- a/src/contributing.md
+++ b/src/contributing.md
@@ -46,6 +46,8 @@ A list of good first issues can be found from the Kuadrant Github [projects boar
 
 If you're interested in working on an issue, start by leaving a comment to let others know — please don't assign yourself straight away. Once you've had a chance to confirm it's a good fit and you're ready to start, then mark yourself as an assignee and update the status to `In Progress`.
 
+We'd encourage you to focus on one issue at a time and see it through to completion — including review feedback and any follow-up — before picking up the next one. Maintainers have limited capacity and are often working across multiple projects, so this helps them give your work the attention it deserves rather than spreading review time across several in-flight PRs.
+
 If an issue already has someone assigned, either let them run with it or drop a comment to see if they'd be open to pairing — but please don't assign yourself over someone who's already working on it. There are plenty of great issues to go around and we're sure you'll find something that's a great fit. If something looks like it may have been abandoned (no activity for a few weeks), drop us a message on [Slack][SlackChannelURL] and we can help figure out next steps.
 
 On the rare occasion that there are no good first issues available, that's OK! There is likely still something for you to work on. If you want to contribute but you don't know where to start or can't find a suitable issue, you can reach out via the [Public Slack channel][SlackChannelURL] for suggestions and/or guidance.
@@ -100,6 +102,8 @@ repository, you can amend your commit with the sign-off by running
     git commit --amend -s 
 
 ## Submitting Pull Requests
+
+Please keep to one open PR per project at a time. Getting a single change reviewed, approved and merged is more valuable than having several PRs open in parallel — it keeps the review queue manageable and means you get faster, more focused feedback. Once your PR is merged, you're welcome to open the next one.
 
 When submitting a pull request against one of the Kuadrant component repositories, should the PR address a particular Github issue please make sure to reference it in the PR description. That said, it is not mandatory for a PR to have an associated issue referenced. In the event of a standalone PR that doesn't have an associated issue, please add a detailed description of the changes included. Adding *What* and *Why* sections is a good start. For example, *What* is the purpose of this change and *Why* is it required and/or being implemented in this way?
 


### PR DESCRIPTION
This is based on learnings from recent influx of community involvement after LFX term 2 2026 project submissions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidelines to encourage completing single issues before starting new work
  * Added recommendation to maintain only one open pull request per project at a time, promoting efficient reviews and manageable review queues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->